### PR TITLE
docs: add AUTHORS to docs with contact info to owner

### DIFF
--- a/docs/AUTHORS
+++ b/docs/AUTHORS
@@ -1,0 +1,7 @@
+There is one mainteiner:
+
+GRIERIOR (Owner)
+https://github.com/GRIERIOR
+grierior@gmail.com
+
+and no other authors.


### PR DESCRIPTION
## Description
In this PR, only docs/AUTHORS is introduced. It contains information about the maintainers (only one for now) and authors. Main use of this file is to provide contact information to owner (me).

## Related Issues
None.

## Additional Notes
Checklist ommited as there is no code changes.