### PR TITLE
fix: typo in docs/AUTHORS; mainteiner -> maintainer

### DIFF
--- a/docs/AUTHORS
+++ b/docs/AUTHORS
@@ -1,4 +1,4 @@
-There is one mainteiner:
+There is one maintainer:
 
 GRIERIOR (Owner)
 https://github.com/GRIERIOR


### PR DESCRIPTION
## Description
Typo in docs/AUTHORS is fixed. `mainteiner` -> `maintainer`.

## Related Issues
Closes #17 