### PR TITLE
fix: remove assert that checks with the expected result 

### DIFF
--- a/src/tests/test_func_solve.py
+++ b/src/tests/test_func_solve.py
@@ -112,10 +112,7 @@ def test_invalid_domain():
 def test_symbolic_linear():
     sol = solve(a*x + b, x)
 
-    # expected: [-b/a]
     assert len(sol) == 1
-    assert simplify(sol[0] + b/a) == 0
-
     assert_solution_satisfies(a*x + b, x, sol[0])
 
 


### PR DESCRIPTION
## Description
This PR removes the wrongly placed assert from `test_func_solve` in the test `test_symbolic_linear`. It was checking with the expected result for the equation which was inconsistent with the test scenario.

## Checklist (DoD of #20)
- [x] `test_symbolic_linear` no longer checks with the expected result.
- [x] The test runs without errors. 

## Related Issues
Closes #20