### PR TITLE
Refactorisation of checklist section from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,10 +3,7 @@ Provide a clear and concise description of what this PR does and why it is neede
 
 ## Checklist
 - [ ] My code builds without errors
-- [ ] All tests pass
-- [ ] I have added tests where necessary
 - [ ] I have updated documentation where necessary
-- [ ] I have checked for unintended side effects
 
 ## Related Issues
 Closes #...

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -25,8 +25,9 @@ docs/<short-description>
 ### PR Title and Template
 PR's title also should obey [conventional commit](https://www.conventionalcommits.org/) format.
 
-A [Pull Request template](../.github/pull_request_template.md) is provided in the repository.  
-Please follow it when creating a PR and fill in all relevant sections to make the review process easier.
+A [Pull Request template](../.github/pull_request_template.md) is provided in the repository. Please follow it when creating a PR and fill in all relevant sections to make the review process easier. 
+
+The **Checklist** section is primarly intended for the code-related changes and may be adjusted manually (e.g. when your PR doesn't introduce any code-related changes, you can omit it). It's also recommended that one adds the Definition of Done (DoD) from related issues to the checklist.
 
 ### PR Size
 Pull Requests should be as small and focused as possible.  


### PR DESCRIPTION
## Description
This PR reduces the **Checklist** section from PR template to minimum that's actually used in reality. The previous version was a little extraneous and not a single PR found use of it's full form. Clarification in `docs/CONTRIBUTING.md` is also introduced; now it's clearly spoken that this section can be adjusted manually if needed.

## Related Issues
Closes #23